### PR TITLE
Adds skipSidebar option for docusaurus2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following arguments can be used in addition to the default [TypeDoc argument
 - `--hideBreadcrumbs`<br>
   Do not print breadcrumbs.
 - `--skipSidebar`<br>
-  Do not update the `sidebar.json` file when used with `docusaurus` theme.
+  Do not update the `sidebar.json` file when used with `docusaurus` or `docusaurus2` theme.
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export = (PluginHost: Application) => {
   });
 
   app.options.addDeclaration({
-    help: 'Skips updating of the sidebar.json file when used with docusaurus theme',
+    help: 'Skips updating of the sidebar.json file when used with docusaurus or docusaurus2 theme',
     name: 'skipSidebar',
     type: ParameterType.Boolean,
   });

--- a/src/subthemes/docusaurus/theme.ts
+++ b/src/subthemes/docusaurus/theme.ts
@@ -15,14 +15,16 @@ export default class DocusaurusTheme extends MarkdownTheme {
   }
 
   onRendererEnd(renderer: RendererEvent) {
-    const docusarusRoot = this.findDocusaurusRoot(renderer.outputDirectory);
-    if (docusarusRoot === null) {
-      this.application.logger.warn(
-        `[typedoc-markdown-plugin] sidebars.json not written as could not locate docusaurus root directory. In order to to implemnent sidebars.json functionality, the output directory must be a child of a 'docs' directory.`,
-      );
-      return;
+    if (!this.application.options.getValue('skipSidebar')) {
+      const docusarusRoot = this.findDocusaurusRoot(renderer.outputDirectory);
+      if (docusarusRoot === null) {
+        this.application.logger.warn(
+          `[typedoc-markdown-plugin] sidebars.json not written as could not locate docusaurus root directory. In order to to implemnent sidebars.json functionality, the output directory must be a child of a 'docs' directory.`,
+        );
+        return;
+      }
+      this.writeSideBar(renderer, docusarusRoot);
     }
-    if (!this.application.options.getValue('skipSidebar')) { this.writeSideBar(renderer, docusarusRoot); }
   }
 
   writeSideBar(renderer: RendererEvent, docusarusRoot: string) {

--- a/src/subthemes/docusaurus2/theme.ts
+++ b/src/subthemes/docusaurus2/theme.ts
@@ -17,14 +17,16 @@ export default class Docusaurus2Theme extends MarkdownTheme {
   }
 
   onRendererEnd(renderer: RendererEvent) {
-    const docusarusRoot = this.findDocusaurus2Root(renderer.outputDirectory);
-    if (docusarusRoot === null) {
-      this.application.logger.warn(
-        `[typedoc-markdown-plugin] ${this.sidebarName} not written as could not locate docusaurus root directory. In order to to implemnent ${this.sidebarName} functionality, the output directory must be a child of a 'docs' directory.`,
-      );
-      return;
+    if (!this.application.options.getValue('skipSidebar')) {
+      const docusarusRoot = this.findDocusaurus2Root(renderer.outputDirectory);
+      if (docusarusRoot === null) {
+        this.application.logger.warn(
+          `[typedoc-markdown-plugin] ${this.sidebarName} not written as could not locate docusaurus root directory. In order to to implemnent ${this.sidebarName} functionality, the output directory must be a child of a 'docs' directory.`,
+        );
+        return;
+      }
+      this.writeSideBar(renderer, docusarusRoot);
     }
-    this.writeSideBar(renderer, docusarusRoot);
   }
 
   writeSideBar(renderer: RendererEvent, docusarusRoot: string) {


### PR DESCRIPTION
* Adds to #107.
* Extends PR #108 to the docusaurus2 theme also.
* Skips finding docusaurus root when skip is enabled.
* Updates documentation to indicate it is usable for both docusaurus themes.